### PR TITLE
fix: fixes #42

### DIFF
--- a/testdata/script/pin_github_actions_42.txtar
+++ b/testdata/script/pin_github_actions_42.txtar
@@ -1,0 +1,27 @@
+exec actlock
+
+stdout '🔧  Authenticated GitHub API access in effect.'
+
+# Compare the modified file (in $WORK) with the expected output (also in $WORK)
+cmp .github/workflows/test.yml expected.yml
+
+
+# Setup initial workflow file relative to the temp $WORK dir
+-- .github/workflows/test.yml --
+name: Test Workflow
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gradle v4 (branch/tag)
+        uses: gradle/actions/setup-gradle@v4 # Known tag/branch
+-- expected.yml --
+name: Test Workflow
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gradle v4 (branch/tag)
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 #v4.4.1

--- a/testdata/script/pin_github_actions_42.txtar
+++ b/testdata/script/pin_github_actions_42.txtar
@@ -1,12 +1,13 @@
-exec actlock
+exec actlock -u
 
+# Check the rate limit message
 stdout '🔧  Authenticated GitHub API access in effect.'
 
-# Compare the modified file (in $WORK) with the expected output (also in $WORK)
+# Check stderr for the processing message
+stderr 'Processing workflow: .github/workflows/test.yml'
+
 cmp .github/workflows/test.yml expected.yml
 
-
-# Setup initial workflow file relative to the temp $WORK dir
 -- .github/workflows/test.yml --
 name: Test Workflow
 on: push


### PR DESCRIPTION
A summary courtesty of Gemini 2.5 Flash-Lite Preview 06-17 (my own experiment)

```
Here's a summary of the key changes:

    Handling of Subpaths in Repository Names: The code now correctly handles repository names that include subpaths (e.g., owner/repo/subpath). It extracts just the repository name (repoNameForAPI) for API calls, while preserving the full path (fullPathForUses) for constructing the updated uses string in the workflow file.

    Improved Logging: Log messages have been updated to be more descriptive and to include the full path of the action being processed, improving clarity during execution.

    Error Handling for Subpaths: Added validation to ensure that a repository name can be extracted from the action.Repo string. If not, it logs a warning and skips processing that specific reference, allowing the tool to continue with other valid references.

    Consistency in uses String Construction: The uses string is now consistently constructed using the fullPathForUses, which includes any subpaths, ensuring that the updated workflow file accurately reflects the original action reference.

    Update to Test Data: The test file testdata/script/pin_github_actions_42.txtar has been modified to include the -u flag in the actlock execution, indicating an update operation. It also adds assertions for the processing message in stderr and the comparison of the modified file.
```
