### PR TITLE
chore: update go to 1.25.3

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,7 @@ version: "2"
 run:
   timeout: 5m
   tests: true
-  go: "1.25.0"
+  go: 1.25.3
 linters:
   enable:
     - dupl

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.25.0
-nodejs 22.16.0
-python 3.12.11
-pnpm 10.17.0
+golang 1.25.3
+nodejs 22.21.1
+python 3.12.12
+pnpm   10.20.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM esacteksab/go:1.25.0-2025-10-24@sha256:f9f3db2fd6f84ad8a12019864094eda9e860b0af47df1fd5e19c90f5539fe400 AS builder
+FROM esacteksab/go:1.25.3-2025-10-25@sha256:0ff5eeb3b6caf277af0563dea4127308a311b9f004dbab3dc909033fd27fa8fe AS builder
 
-# Set GOMODCACHE explicitly
 ENV GOMODCACHE=/go/pkg/mod
 
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/esacteksab/gh-actlock
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/esacteksab/httpcache v0.2.0

--- a/go.tool.mod
+++ b/go.tool.mod
@@ -1,7 +1,7 @@
 // How to use https://www.alexedwards.net/blog/how-to-manage-tool-dependencies-in-go-1.24-plus
 module github.com/esacteksab/gh-actlock
 
-go 1.25.0
+go 1.25.3
 
 tool (
 	github.com/segmentio/golines


### PR DESCRIPTION
Addresses findings in `make audit`

```bash
Make Audit...............................................................Failed
- hook id: make-audit
- exit code: 2

go mod tidy
go tool -modfile=go.tool.mod golines --base-formatter=gofumpt -w .
go tool -modfile=go.tool.mod gofumpt -l -w -extra .
go vet ./...
go tool -modfile=go.tool.mod staticcheck ./...
go tool -modfile=go.tool.mod govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.2
    Example traces found:
      #1: parser/parser.go:213:15: parser.FindAllActions calls fmt.Printf, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4012
    Lack of limit when parsing cookies can cause memory exhaustion in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-4012
  Standard library
    Found in: net/http@go1.25
    Fixed in: net/http@go1.25.2
    Example traces found:
      #1: githubclient/client.go:239:46: githubclient.GetLatestActionRef calls github.RepositoriesService.ListTags, which eventually calls http.Client.Do

Vulnerability #3: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.25
    Fixed in: encoding/asn1@go1.25.2
    Example traces found:
      #1: githubclient/client.go:8:2: githubclient.init calls http.init, which eventually calls asn1.Unmarshal

Vulnerability #4: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.25
    Fixed in: net/url@go1.25.2
    Example traces found:
      #1: githubclient/client.go:122:28: githubclient.NewClient calls github.NewClient, which eventually calls url.Parse
      #2: githubclient/client.go:239:46: githubclient.GetLatestActionRef calls github.RepositoriesService.ListTags, which eventually calls url.URL.Parse

Vulnerability #5: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.25
    Fixed in: encoding/pem@go1.25.2
    Example traces found:
      #1: githubclient/client.go:8:2: githubclient.init calls http.init, which eventually calls pem.Decode

Vulnerability #6: GO-2025-4008
    ALPN negotiation error contains attacker controlled information in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2025-4008
  Standard library
    Found in: crypto/tls@go1.25
    Fixed in: crypto/tls@go1.25.2
    Example traces found:
      #1: githubclient/client.go:67:30: githubclient.CachingTransport.RoundTrip calls httpcache.Transport.RoundTrip, which eventually calls tls.Conn.HandshakeContext
      #2: githubclient/client.go:239:46: githubclient.GetLatestActionRef calls github.RepositoriesService.ListTags, which eventually calls tls.Conn.Read
      #3: parser/parser.go:213:15: parser.FindAllActions calls fmt.Printf, which eventually calls tls.Conn.Write
      #4: githubclient/client.go:67:30: githubclient.CachingTransport.RoundTrip calls httpcache.Transport.RoundTrip, which eventually calls tls.Dialer.DialContext

Vulnerability #7: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.25
    Fixed in: crypto/x509@go1.25.3
    Example traces found:
      #1: githubclient/client.go:8:2: githubclient.init calls http.init, which eventually calls x509.CertPool.AppendCertsFromPEM
      #2: parser/parser.go:213:15: parser.FindAllActions calls fmt.Printf, which eventually calls x509.Certificate.Verify
      #3: githubclient/client.go:8:2: githubclient.init calls http.init, which eventually calls x509.ParseCertificate

Your code is affected by 7 vulnerabilities from the Go standard library.
This scan also found 2 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
make: *** [Makefile:12: audit] Error 3
```